### PR TITLE
SolidWorksReader: Don't guess the initial state of the service

### DIFF
--- a/SolidWorksReader.py
+++ b/SolidWorksReader.py
@@ -168,13 +168,16 @@ class SolidWorksReader(CommonCOMReader):
         options = super().startApp(options)
 
         # Allow SolidWorks to run in the background and be invisible
+        options["app_instance_user_control"] = options["app_instance"].UserControl
         options["app_instance"].UserControl = False
 
         #  ' If the following property is true, then the SolidWorks frame will be visible on a call to ISldWorks::ActivateDoc2; so set it to false
+        options["app_instance_visible"] = options["app_instance"].Visible
         options["app_instance"].Visible = False
 
         # Keep SolidWorks frame invisible when ISldWorks::ActivateDoc2 is called
         options["app_frame"] = options["app_instance"].Frame
+        options["app_frame_invisible"] = options["app_frame"].KeepInvisible
         options["app_frame"].KeepInvisible = True
 
         # Getting revision after starting
@@ -213,13 +216,16 @@ class SolidWorksReader(CommonCOMReader):
     def closeApp(self, options):
         if "app_frame" in options.keys():
             # Normally, we want to do that, but this confuses SolidWorks more than needed, it seems.
-            #options["app_frame"].KeepInvisible = False
-            pass
+            if "app_frame_invisible" in options.keys():
+                options["app_frame"].KeepInvisible = options["app_frame_invisible"]
+            
         if "app_instance" in options.keys():
             # Same here. By logic I would assume that we need to undo it, but when processing multiple parts, SolidWorks gets confused again..
             # Or there is another sense..
-            #options["app_instance"].Visible = True
-            pass
+            if "app_instance_visible" in options.keys():
+                options["app_instance"].Visible = options["app_instance_visible"]
+            if "app_instance_user_control" in options.keys():
+                options["app_instance"].UserControl = options["app_instance_user_control"]
 
     def walkComponentsInAssembly(self, root = None):
         if root is None:


### PR DESCRIPTION
Caching more variables and restoring them at the end